### PR TITLE
binary_check test: Fix to include src path

### DIFF
--- a/test/miscellaneous/binary_check/test.sh
+++ b/test/miscellaneous/binary_check/test.sh
@@ -2,6 +2,9 @@
 
 # Script that checks for any binary blobs in the commit and raises errors if any are present
 
+# IncludeOS_src directory
+INCLUDEOS_SRC=${INCLUDEOS_SRC-~/IncludeOS}
+
 # Make sure dev is fully updated and that we are standing in pull request
 target_branch=${ghprbTargetBranch-dev}
 
@@ -10,10 +13,10 @@ files_changed=`git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH
 
 # Loop over files and check for binary blobs
 for single_file in $files_changed; do
-	filetype=`file -i $single_file`
+	filetype=`file -i $INCLUDEOS_SRC/$single_file`
     echo $filetype | grep -q charset=binary
     if [ $? -eq 0 ]; then
-        echo Error: The file $single_file has been detected as a binary file
+        echo Error: The file $INCLUDEOS_SRC/$single_file has been detected as a binary file
         exit 1
     fi
 done


### PR DESCRIPTION
Should now correctly detect the binary in https://github.com/hioa-cs/IncludeOS/pull/899
